### PR TITLE
Incorrect render prototype in class GalleryContent

### DIFF
--- a/gallery/models.py
+++ b/gallery/models.py
@@ -128,7 +128,8 @@ class GalleryContent(models.Model):
         verbose_name_plural = _('Image Galleries')
 
 
-    def render(self, request, **kwargs):
+    def render(self, **kwargs):
+        request = kwargs.get('request')
         objects = self.gallery.ordered_images()
         remaining = []
         if len(objects) == 1:


### PR DESCRIPTION
According to the feincms standard the render function in a content type should be prototyped as:
def render(self, **kwargs)
The request should be passed through a keyword argument
