### PR TITLE
Fix jquery "live" removal from version 1.7 and upper

### DIFF
--- a/gallery/templates/admin/gallery/gallery/change_form.html
+++ b/gallery/templates/admin/gallery/gallery/change_form.html
@@ -38,7 +38,7 @@
                 elem.siblings('span').remove().end();
                 elem.css('width', '30px').after("<span class=\"lupe mediafile\" id=\"lookup_"+this.id+"\"> <img src=\"{{ STATIC_URL }}admin/img/selector-search.gif\" alt=\"{% trans "Search" %}\" /></span>");
             });
-            $('span.lupe.mediafile').live('click', function(){
+	    $(document).on('click', 'span.lupe.mediafile', function(){
 				LoupeClicked = $(this).prev('input');
                 var name = id_to_windowname(this.id.replace(/^lookup_/, ''));
                 var win = window.open('{% if frontend_editing %}../../{% endif %}../../../medialibrary/mediafile/?pop=1', name, 'height=500,width=800,resizable=yes,scrollbars=yes');


### PR DESCRIPTION
http://jquery.com/upgrade-guide/1.9/#live-removed
In Django 1.6.x, the jQuery library embedded in the admin has been upgraded to version 1.9.1.
