### PR TITLE
Updated to work with latest Django (1.11), FeinCMS (v1.13.1), and Fancybox (v3.0.47)

### DIFF
--- a/gallery/models.py
+++ b/gallery/models.py
@@ -127,8 +127,13 @@ class GalleryContent(models.Model):
             current_page, paginator = None, None
             images = objects
 
-        return render_to_string(self.spec.templates,
-                {'content': self, 'block':current_page,
-                'images': images, 'paginator': paginator,
-                'remaining': remaining, 'request': request },
-            context_instance = RequestContext(request))
+        context = {
+            'content': self, 
+            'block': current_page,
+            'images': images, 
+            'paginator': paginator,
+            'remaining': remaining, 
+            'request': request
+        }
+        
+        return render_to_string(self.spec.templates, context=context, request=request)

--- a/gallery/specs/legacy.py
+++ b/gallery/specs/legacy.py
@@ -1,5 +1,6 @@
 """ Dowload fancybox from:
-    http://fancybox.googlecode.com/files/jquery.fancybox-1.3.4.zip
+    http://fancyapps.com/fancybox/3
+    v3.0.47
 """
 
 from django.utils.translation import ugettext_lazy as _
@@ -15,9 +16,9 @@ class ClassicLightbox(BaseSpec):
     name = 'p.classiclm'
 
     media = {
-        'css': {'all': ('lib/fancybox/jquery.fancybox-1.3.4.css',
+        'css': {'all': ('fancybox/jquery.fancybox.min.css',
                         'content/gallery/classic.css')},
-        'js': ('lib/fancybox/jquery.fancybox-1.3.4.pack.js',
+        'js': ('fancybox/jquery.fancybox.min.js',
                'content/gallery/gallery.js'),
     }
 

--- a/gallery/urls.py
+++ b/gallery/urls.py
@@ -1,11 +1,11 @@
 try:
-    from django.conf.urls import patterns, url
+    from django.conf.urls import url
 except ImportError:  # Older Django versions
-    from django.conf.urls.defaults import patterns, url
+    from django.conf.urls.defaults import url
 
 from gallery.admin import admin_thumbnail
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^thumbnail/$', admin_thumbnail, name='gallery_admin_thumbnail'),
-)
+]


### PR DESCRIPTION
Greetings,

**Environment**
    Django==1.11
    FeinCMS==1.13.1
    feincms-gallery==1.2.4

**Edits**
    * updated to work with fancybox v3.0.47 (NOTE: location of the js files modified slightly)
    * updated GalleryContent `render_to_string` function
    * updated urls.py

Please verify and update accordingly.  Thank you for your time.

satadev